### PR TITLE
feat: block access to .htaccess within nginx

### DIFF
--- a/front/nginx.conf
+++ b/front/nginx.conf
@@ -48,4 +48,8 @@ server {
     location ~ ^/[@_*]/ {
         try_files $uri $uri/ /index.html;
     }
+
+    location ^~ /.htaccess/ {
+        return 404;
+    }
 }


### PR DESCRIPTION
Yes, it's not in use for nginx. However, it's available within public folder and therefore detected by security scanners.